### PR TITLE
Standardize error type for all _distutils.modified methods

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -30,7 +30,8 @@ disable_error_code = attr-defined
 [mypy-pkg_resources.tests.*]
 disable_error_code = import-not-found
 
-# - distutils._modified has different errors on Python 3.8 [import-untyped], on Python 3.9+ [import-not-found]
+# - distutils._modified has different errors on Python 3.8 on Windows only [import-untyped],
+#   where it's an [import-not-found] on all other platforms and versions
 # - All jaraco modules are still untyped
 # - _validate_project sometimes complains about trove_classifiers (#4296)
 # - wheel appears to be untyped

--- a/newsfragments/4567.bugfix.rst
+++ b/newsfragments/4567.bugfix.rst
@@ -1,0 +1,1 @@
+Ensured all methods in `setuptools.modified` raise a consistant `distutils.error.DistutilsError` type -- by :user:`Avasam`

--- a/setuptools/command/build_clib.py
+++ b/setuptools/command/build_clib.py
@@ -1,12 +1,8 @@
+from ..modified import newer_pairwise_group
+
 import distutils.command.build_clib as orig
 from distutils import log
 from distutils.errors import DistutilsSetupError
-
-try:
-    from distutils._modified import newer_pairwise_group
-except ImportError:
-    # fallback for SETUPTOOLS_USE_DISTUTILS=stdlib
-    from .._distutils._modified import newer_pairwise_group
 
 
 class build_clib(orig.build_clib):

--- a/setuptools/modified.py
+++ b/setuptools/modified.py
@@ -1,8 +1,18 @@
-from ._distutils._modified import (
-    newer,
-    newer_group,
-    newer_pairwise,
-    newer_pairwise_group,
-)
+try:
+    # Ensure a DistutilsError raised by these methods is the same as distutils.error.DistutilsError
+    from distutils._modified import (  # type: ignore[import-not-found]
+        newer,
+        newer_group,
+        newer_pairwise,
+        newer_pairwise_group,
+    )
+except ImportError:
+    # fallback for SETUPTOOLS_USE_DISTUTILS=stdlib, because _modified never existed in stdlib
+    from ._distutils._modified import (
+        newer,
+        newer_group,
+        newer_pairwise,
+        newer_pairwise_group,
+    )
 
 __all__ = ['newer', 'newer_pairwise', 'newer_group', 'newer_pairwise_group']


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
